### PR TITLE
fix stale timer

### DIFF
--- a/lib/hooks/launchpad.ts
+++ b/lib/hooks/launchpad.ts
@@ -133,6 +133,14 @@ export function useTimer() {
     };
   }, [deadline]);
 
+  useEffect(() => {
+    if (deadline === 0) {
+      setTimeLeft(0);
+    } else {
+      setTimeLeft(deadline * 1000);
+    }
+  }, [deadline]);
+
   return timeLeft > 0
     ? {
         days: Math.floor(timeLeft / DAY),


### PR DESCRIPTION
Here's how to reproduce the bug:

1. open a new private browser window
2. visit launchpad

You can find the remaining time to be `0d 0h 0m`.

Now refresh the page, it will get updated.

btw, don't have any other same page opened when testing, otherwise it cant be reproduced.